### PR TITLE
better handling for single static eventsub

### DIFF
--- a/Headless/TwitchHandler/Twitch.cs
+++ b/Headless/TwitchHandler/Twitch.cs
@@ -45,14 +45,6 @@ namespace TwitchHandler
 
         public void Connect()
         {
-            if(EventSub.Connected)
-            {
-                EventSub.StaleReconnectionToken();
-            }
-            else
-            {
-                EventSub.ConnectWithRetryAsync();
-            }
 
             ConnectionCredentials credentials = new ConnectionCredentials("umbotas", bot_access_token);
             var clientOptions = new ClientOptions
@@ -75,6 +67,9 @@ namespace TwitchHandler
             {
                 throw new BadRequestException($"Invalid token for {ChannelName}");
             }
+
+            EventSub.AttemptConnection();
+            EventSub.WaitForConnectionAsync().Wait();
 
             client.OnLog += Client_OnLog;
             client.OnUserJoined += Client_OnUserJoined;
@@ -125,7 +120,6 @@ namespace TwitchHandler
                 }
             }
         }
-
 
         public void SendChatMessage(string message, TwitchClient client)
         {

--- a/Program.cs
+++ b/Program.cs
@@ -22,7 +22,6 @@ namespace JotasAtrapalhanciaPortal
             HttpServer.Run(new FirebaseAuthHandler(), SocketManager.SocketServer);
 
             Console.ReadLine();
-
         }
 
         private static void HttpServer_OnGameConnected(object? sender, GameConnectedEventArgs args)


### PR DESCRIPTION
Eventsub needs to be a static class with a single connection because by design, the twitch websocket can only accept one user by ip, and my single machine is the only connected client, regardless of how many broadcaster are connected... 

You know, tcp servers just accept a single user by ip because... you know... its a tcp server